### PR TITLE
Treat head bubble identically to colour bubbles

### DIFF
--- a/bubble-shooter.html
+++ b/bubble-shooter.html
@@ -28,7 +28,7 @@ const {
   R, COLS, MAX_ROWS, FILL_ROWS,
   BUBBLE_SPEED, MATCH_COUNT, SHOTS_PER_NEW_ROW, POINTS_PER_BUBBLE,
   AIM_GUIDE_LENGTH, AIM_GUIDE_POST_BOUNCE,
-  HEAD_ID, HEAD_CHANCE, HEAD_IMAGE_SRC,
+  HEAD_ID, HEAD_IMAGE_SRC,
   WIJNTJE_TEXT, WIJNTJE_MIN_POP, WIJNTJE_DURATION,
   COLORS,
 } = CONFIG;
@@ -79,9 +79,7 @@ let grid, score, shotsFired, pendingNewRow, availableColors, gameOver, winner, f
     wijntjeTimer, wijntjeStart;
 
 // Always draw from the shrinking pool of colors still in play.
-// HEAD_ID is excluded from availableColors and handled via HEAD_CHANCE instead.
 function rndColor() {
-  if (Math.random() < HEAD_CHANCE) return HEAD_ID;
   return availableColors[Math.random() * availableColors.length | 0];
 }
 
@@ -99,7 +97,7 @@ function pruneColors() {
 }
 
 function init() {
-  availableColors = [...COLORS];   // full palette; shrinks as colours are cleared
+  availableColors = [...COLORS, HEAD_ID];  // full palette incl. head; shrinks as types are cleared
   grid            = Array.from({ length: MAX_ROWS }, (_, r) => new Array(colCount(r)).fill(null));
   score           = 0;
   shotsFired      = 0;

--- a/config.js
+++ b/config.js
@@ -16,8 +16,7 @@ const CONFIG = {
   POINTS_PER_BUBBLE: 10,  // score awarded per bubble cleared
 
   // ── Head bubble (special type; renders as a face image instead of a colour) ─
-  HEAD_ID:        'head',       // internal identifier – never treated as a colour string
-  HEAD_CHANCE:    0.12,         // probability any randomly generated bubble is a head
+  HEAD_ID:        'head',       // internal identifier – treated like a colour for all game logic
   HEAD_IMAGE_SRC: 'piet.jpg',   // path to the head photo (place the file next to index.html)
 
   // ── Aim guide ───────────────────────────────────────────────────────────────


### PR DESCRIPTION
HEAD_ID is now part of availableColors from the start, so it appears with the same 1-in-7 probability as every other colour and is pruned by the existing elimination logic when no head bubbles remain anywhere.

Removed HEAD_CHANCE – the special per-shot probability is gone.

https://claude.ai/code/session_01L3jnuTkyhbzMo7sB9di9G9